### PR TITLE
full functionality on calculator

### DIFF
--- a/empathy-builder/src/components/Calculator.js
+++ b/empathy-builder/src/components/Calculator.js
@@ -53,12 +53,6 @@ const Column = styled.div`
 
 const Calculator = props => {
     
-    
-
-
-    const [recurringTotal, setRecurringTotal] = useState(0);
-    const [relocationTotal, setRelocationTotal] = useState(0);
-    
     const [recurringCategoryTotals, setRecurringCategoryTotals] = useState({
         Food: 0,
         Transportation: 0,
@@ -76,28 +70,17 @@ const Calculator = props => {
         Miscellaneous: 0,
     });
 
-    
+    const Sum = obj => {
+        return Object.keys(obj).reduce((sum, key) => sum+parseFloat(obj[key] || 0), 0);
+    };
 
-
-
-    const updateRecurringTotal = (amount) => {
-        let newSum = recurringTotal + amount;
-        setRecurringTotal(newSum);
-
-    }
-
-    const updateRelocationTotal = (item) => {
-        console.log(item)
-        const recurringCopy = [...recurringTotal];
-        //const categoryIndex = recurringCopy.findIndex(somehow select object with matching category and update that objects sum value);
-        setRelocationTotal(recurringCopy) 
-    }	    
-
+    const recurringCalcTotal = Sum(recurringCategoryTotals)
+    const relocationCalcTotal = Sum(relocationCategoryTotals)
  
     return(
         <CalcPage>
             <Results>
-                <h2>Total Cost for Relocation: ${recurringTotal + relocationTotal} </h2>
+                <h2>Total Cost for Relocation: ${recurringCalcTotal + relocationCalcTotal} </h2>
 
             </Results>
         
@@ -105,18 +88,18 @@ const Calculator = props => {
                 <Column>
                     <h2>My Recurring Expenses</h2>
                     {personalCosts.map(category => {
-                        return <LineItem key={category.name} categoryTotals={recurringCategoryTotals} setCategoryTotals={setRecurringCategoryTotals} category={category} updateRecurringTotal={updateRecurringTotal} 
+                        return <LineItem key={category.name} categoryTotals={recurringCategoryTotals} setCategoryTotals={setRecurringCategoryTotals} category={category}
                             />
                     })}
-                    <h3>Total Recurring Expenses: $</h3>
+                    <h3>Total Recurring Expenses: ${recurringCalcTotal}</h3>
                 </Column>
                 <Column>
                     <h2>My Relocation Expenses</h2>
                     {relocationCosts.map(category => {
-                        return <LineItem key={category.name} categoryTotals={relocationCategoryTotals} setCategoryTotals={setRelocationCategoryTotals} category={category} updateRelocationTotal={updateRelocationTotal} 
+                        return <LineItem key={category.name} categoryTotals={relocationCategoryTotals} setCategoryTotals={setRelocationCategoryTotals} category={category} 
                             />
                     })}
-                    <h3>Total Relocation Expenses: ${Math.floor(relocationTotal)}</h3>
+                    <h3>Total Relocation Expenses: ${relocationCalcTotal}</h3>
 
                 </Column>
             </CalculatorHolder>

--- a/empathy-builder/src/components/Calculator.js
+++ b/empathy-builder/src/components/Calculator.js
@@ -58,6 +58,7 @@ const Calculator = props => {
 
     const [recurringTotal, setRecurringTotal] = useState(0);
     const [relocationTotal, setRelocationTotal] = useState(0);
+    
     const [recurringCategoryTotals, setRecurringCategoryTotals] = useState({
         Food: 0,
         Transportation: 0,
@@ -70,7 +71,6 @@ const Calculator = props => {
 
     const [relocationCategoryTotals, setRelocationCategoryTotals] = useState({
         Career: 0,
-        Lodging: 0,
         Housing: 0,
         Transportation: 0,
         Miscellaneous: 0,
@@ -88,7 +88,10 @@ const Calculator = props => {
 
     const updateRelocationTotal = (item) => {
         console.log(item)
-    }
+        const recurringCopy = [...recurringTotal];
+        //const categoryIndex = recurringCopy.findIndex(somehow select object with matching category and update that objects sum value);
+        setRelocationTotal(recurringCopy) 
+    }	    
 
  
     return(
@@ -102,7 +105,7 @@ const Calculator = props => {
                 <Column>
                     <h2>My Recurring Expenses</h2>
                     {personalCosts.map(category => {
-                        return <LineItem key={category.name} category={category} updateRecurringTotal={updateRecurringTotal} 
+                        return <LineItem key={category.name} categoryTotals={recurringCategoryTotals} setCategoryTotals={setRecurringCategoryTotals} category={category} updateRecurringTotal={updateRecurringTotal} 
                             />
                     })}
                     <h3>Total Recurring Expenses: $</h3>
@@ -110,7 +113,7 @@ const Calculator = props => {
                 <Column>
                     <h2>My Relocation Expenses</h2>
                     {relocationCosts.map(category => {
-                        return <LineItem key={category.name} category={category} updateRelocationTotal={updateRelocationTotal} 
+                        return <LineItem key={category.name} categoryTotals={relocationCategoryTotals} setCategoryTotals={setRelocationCategoryTotals} category={category} updateRelocationTotal={updateRelocationTotal} 
                             />
                     })}
                     <h3>Total Relocation Expenses: ${Math.floor(relocationTotal)}</h3>

--- a/empathy-builder/src/components/LineItem.js
+++ b/empathy-builder/src/components/LineItem.js
@@ -33,19 +33,16 @@ const LineItem = props => {
 
     const [categoryCosts, setCategoryCosts] = useState({});
 
-
-
-
     const handleRecurringOk = (e) => {
         e.preventDefault();
-        props.updateRecurringTotal(categorySum);
+        props.updateRecurringTotal({[props.category.name]: categorySum})
         setModalVisible(false);
 
       };
 
     const handleRelocationOk = e => {
     e.preventDefault();
-    props.updateRecurringTotal({[props.category.name]: categorySum})
+    props.updateRelocationTotal({[props.category.name]: categorySum})
     setModalVisible(false);
     };
 
@@ -67,7 +64,15 @@ const LineItem = props => {
 
     const categorySum = Sum(categoryCosts);    
     
-    
+    useEffect(() => {
+        props.setCategoryTotals({
+            ...props.categoryTotals,
+            [props.category.name]: categorySum
+        })
+        }, [categorySum])
+        
+    console.log(props)
+
     return(
         
         <>
@@ -83,6 +88,7 @@ const LineItem = props => {
             >
             <h3>Things to consider: </h3>
                 {props.category.categories.map(category => {
+                    
                 return(
                     <InputLine key={category}>
                         <p>{category}</p>

--- a/empathy-builder/src/components/LineItem.js
+++ b/empathy-builder/src/components/LineItem.js
@@ -33,18 +33,10 @@ const LineItem = props => {
 
     const [categoryCosts, setCategoryCosts] = useState({});
 
-    const handleRecurringOk = (e) => {
+    const handleModal = (e) => {
         e.preventDefault();
-        props.updateRecurringTotal({[props.category.name]: categorySum})
         setModalVisible(false);
-
       };
-
-    const handleRelocationOk = e => {
-    e.preventDefault();
-    props.updateRelocationTotal({[props.category.name]: categorySum})
-    setModalVisible(false);
-    };
 
     const handleCancel = e => {
         setModalVisible(false);
@@ -70,7 +62,7 @@ const LineItem = props => {
             [props.category.name]: categorySum
         })
         }, [categorySum])
-        
+
     console.log(props)
 
     return(
@@ -83,7 +75,7 @@ const LineItem = props => {
             <Modal
             title={props.category.name}
             visible={modalVisible}
-            onOk={e => {props.updateRecurringTotal ? handleRecurringOk(e) : handleRelocationOk(e)}}
+            onOk={e => handleModal(e)}
             onCancel={handleCancel}
             >
             <h3>Things to consider: </h3>


### PR DESCRIPTION
Paired with @wvanorder 

Original blocker: the calculators could add cumulatively as new category amounts were entered, but couldn't subtract or update the total if an individual category was changed.

Solution: instead of state being `0` (i.e. balance) that's added to, our state is an object containing all of the totals. We're using useEffect and spread to update that object and calculating sum from there.